### PR TITLE
Update dependencies to Oxalis and vefa-peppol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <ringo.version>1.1.29</ringo.version>
-        <oxalis.version>4.0.0-RC2</oxalis.version>
+        <oxalis.version>4.0.2</oxalis.version>
         <vefa.peppol.groupId>no.difi.vefa</vefa.peppol.groupId>
-        <vefa.peppol.version>0.9.7</vefa.peppol.version>
+        <vefa.peppol.version>1.0.4</vefa.peppol.version>
     </properties>
 
     <dependencyManagement>

--- a/spiralis-common/src/main/java/no/balder/spiralis/jdbc/SpiralisTaskPersisterImpl.java
+++ b/spiralis-common/src/main/java/no/balder/spiralis/jdbc/SpiralisTaskPersisterImpl.java
@@ -92,11 +92,11 @@ public class SpiralisTaskPersisterImpl implements SpiralisTaskPersister {
 
 
             if (spiralisReceptionTask.getInboundMetadata().getTransmissionIdentifier() != null) {
-                ps.setString(12, spiralisReceptionTask.getInboundMetadata().getTransmissionIdentifier().getValue());
+                ps.setString(12, spiralisReceptionTask.getInboundMetadata().getTransmissionIdentifier().getIdentifier());
             } else
                 ps.setString(12, null);
 
-            ps.setString(13, spiralisReceptionTask.getInboundMetadata().getHeader().getIdentifier().getValue());
+            ps.setString(13, spiralisReceptionTask.getInboundMetadata().getHeader().getIdentifier().getIdentifier());
 
             final String receiverOrgNo = spiralisReceptionTask.getInboundMetadata().getHeader().getReceiver().getIdentifier().toString();
             ps.setString(14, receiverOrgNo);

--- a/spiralis-common/src/main/java/no/balder/spiralis/tool/ObjectMother.java
+++ b/spiralis-common/src/main/java/no/balder/spiralis/tool/ObjectMother.java
@@ -116,11 +116,10 @@ public class ObjectMother {
                 return ObjectMother.sampleCertificate();
             }
 
-			@Override
-			public Tag getTag() {
-				// FIXME
-				return Tag.of("SomeTag");
-			}
+            @Override
+            public Tag getTag() {
+                return Tag.of("SomeTag");
+            }
         };
     }
 

--- a/spiralis-common/src/main/java/no/balder/spiralis/tool/ObjectMother.java
+++ b/spiralis-common/src/main/java/no/balder/spiralis/tool/ObjectMother.java
@@ -2,6 +2,7 @@ package no.balder.spiralis.tool;
 
 import no.difi.oxalis.api.inbound.InboundMetadata;
 import no.difi.oxalis.api.model.TransmissionIdentifier;
+import no.difi.oxalis.api.tag.Tag;
 import no.difi.vefa.peppol.common.code.DigestMethod;
 import no.difi.vefa.peppol.common.model.*;
 
@@ -114,6 +115,12 @@ public class ObjectMother {
             public X509Certificate getCertificate() {
                 return ObjectMother.sampleCertificate();
             }
+
+			@Override
+			public Tag getTag() {
+				// FIXME
+				return Tag.of("SomeTag");
+			}
         };
     }
 

--- a/spiralis-common/src/main/java/no/balder/spiralis/tool/gson/InboundMetaDataDeserializer.java
+++ b/spiralis-common/src/main/java/no/balder/spiralis/tool/gson/InboundMetaDataDeserializer.java
@@ -92,11 +92,11 @@ class InboundMetaDataDeserializer implements JsonDeserializer<InboundMetadata> {
                     return getJson(j, ctx, "primaryReceipt", Receipt.class);
                 }
 
-				@Override
-				public Tag getTag() {
-					// FIXME
-					return Tag.NONE;
-				}
+                @Override
+                public Tag getTag() {
+                    //FIXME
+                    return Tag.NONE;
+		}
             };
         }
     }

--- a/spiralis-common/src/main/java/no/balder/spiralis/tool/gson/InboundMetaDataDeserializer.java
+++ b/spiralis-common/src/main/java/no/balder/spiralis/tool/gson/InboundMetaDataDeserializer.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import no.difi.oxalis.api.inbound.InboundMetadata;
 import no.difi.oxalis.api.model.TransmissionIdentifier;
+import no.difi.oxalis.api.tag.Tag;
 import no.difi.vefa.peppol.common.model.*;
 
 import java.io.ByteArrayInputStream;
@@ -90,6 +91,12 @@ class InboundMetaDataDeserializer implements JsonDeserializer<InboundMetadata> {
                 public Receipt primaryReceipt() {
                     return getJson(j, ctx, "primaryReceipt", Receipt.class);
                 }
+
+				@Override
+				public Tag getTag() {
+					// FIXME
+					return Tag.NONE;
+				}
             };
         }
     }


### PR DESCRIPTION
This brings vefa-spiralis to a working state against latest release of Oxalis and vefa-peppol. Current upstream master builds, but has runtime errors due to changes in models in vefa-peppol which breaks serialization/deserialization in the inbound handler and Azure plugin.

The InboundMetadata interface now includes a Tag concept, the meaning of which is unclear to me. A simple method has been added to satisfy the interface, and this seems to work, but this should probably be addressed.